### PR TITLE
Add lychee broken-link check workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,46 @@
+name: Link Check
+
+on:
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 6 * * 1' # Monday 06:00 UTC, catch external link rot
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.145.0'
+          extended: true
+
+      - name: Build site
+        run: hugo --minify
+
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config lychee.toml
+            --no-progress
+            --root-dir ${{ github.workspace }}/public
+            'public/**/*.html'
+          fail: false # report only, never block
+
+      - name: Create issue on broken links
+        if: github.event_name == 'schedule' && steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Broken links detected
+          content-filepath: ./lychee/out.md
+          labels: broken-links

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,13 @@
+# lychee link-checker config. See https://github.com/lycheeverse/lychee
+# Used by .github/workflows/link-check.yml
+
+# Treat rate-limit as OK, not broken
+accept = ["200", "429"]
+
+# Skip known false positives
+exclude = [
+  "linkedin\\.com",          # returns 999 to bots, never resolvable in CI
+  "/tinylist/api/subscribe", # newsletter POST endpoint, not a static page
+  "goatcounter\\.com",       # analytics beacon, TLS handshake quirk
+  "void\\(0\\)",             # javascript: no-op hrefs
+]


### PR DESCRIPTION
Report-only on PRs, weekly cron opens issue on broken links. Closes #28